### PR TITLE
Css input error #98

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2975,6 +2975,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"

--- a/client/src/component/Login.jsx
+++ b/client/src/component/Login.jsx
@@ -6,7 +6,7 @@ import "./css/Login.css";
 
 const host = "http://localhost:5000";
 
-const Login = (props) => {
+const Login = ({mode}) => {
   const [credentials, setCredentials] = useState({ email: "", password: "" });
   const [forgotPasswordModalVisible, setForgotPasswordModalVisible] =
     useState(false);
@@ -132,6 +132,11 @@ const Login = (props) => {
             name="email"
             aria-describedby="emailHelp"
             autoComplete="on"
+            style={{
+              backgroundColor: mode === 'dark' ? 'black' : 'white',
+              color: mode === 'dark' ? 'white' : 'black',
+            }}
+
           />
           <i className="fa-solid fa-user"></i>
         </div>
@@ -145,8 +150,15 @@ const Login = (props) => {
             onChange={onChange}
             name="password"
             autoComplete="on"
+            style={{
+              backgroundColor: mode === 'dark' ? 'black' : 'white',
+              color: mode === 'dark' ? 'white' : 'black',
+            }}
           />
-          <i className="fa-solid fa-lock"></i>
+          <i className="fa-solid fa-lock"  style={{
+        backgroundColor: mode === 'dark' ? 'black' : 'white',
+        color: mode === 'dark' ? 'white' : 'black',
+      }}></i>
         </div>
         <Button className="submit" type="submit" onChange={onChange}>
           Login

--- a/client/src/component/Signup.jsx
+++ b/client/src/component/Signup.jsx
@@ -10,7 +10,7 @@ import { registerValidation } from "../validations/validation";
 // import { auth } from '../component/Firebase/Setup';
 const host = "http://localhost:5000";
 
-const Signup = (props) => {
+const Signup = ({mode}) => {
   // const [value, setValue] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -274,9 +274,16 @@ const Signup = (props) => {
             id="name"
             autoComplete="on"
             value={name}
+            style={{
+              backgroundColor: mode === 'dark' ? 'black' : 'white',
+              color: mode === 'dark' ? 'white' : 'black',
+            }}
           />
           {errors.name && <div className="text-danger">{errors.name}</div>}
-          <i className="fa-solid fa-user"></i>
+          <i className="fa-solid fa-user"  style={{
+        backgroundColor: mode === 'dark' ? 'black' : 'white',
+        color: mode === 'dark' ? 'white' : 'black',
+      }}></i>
         </div>
         <div className="inp">
           <input
@@ -289,11 +296,18 @@ const Signup = (props) => {
             aria-describedby="emailHelp"
             autoComplete="on"
             value={email}
+            style={{
+              backgroundColor: mode === 'dark' ? 'black' : 'white',
+              color: mode === 'dark' ? 'white' : 'black',
+            }}
           />
           {errors.email && <div className="text-danger">{errors.email}</div>}
           <i className="fa-solid fa-user"></i>
         </div>
-        <div className="inp">
+        <div className="inp"  style={{
+        backgroundColor: mode === 'dark' ? 'black' : 'white',
+        color: mode === 'dark' ? 'white' : 'black',
+      }}>
           <input
             type={showPassword ? "text" : "password"}
             className="input"
@@ -304,9 +318,16 @@ const Signup = (props) => {
             minLength={5}
             autoComplete="on"
             value={password}
+            style={{
+              backgroundColor: mode === 'dark' ? 'black' : 'white',
+              color: mode === 'dark' ? 'white' : 'black',
+            }}
           />
           {errors.password && (
-            <div className="text-danger">{errors.password}</div>
+            <div className="text-danger"  style={{
+              backgroundColor: mode === 'dark' ? 'black' : 'white',
+              color: mode === 'dark' ? 'white' : 'black',
+            }}>{errors.password}</div>
           )}
           <button
             type="button"
@@ -319,7 +340,10 @@ const Signup = (props) => {
               <Eye className="w-5 h-5" />
             )}
           </button>
-          <i className="fa-solid fa-user"></i>
+          <i className="fa-solid fa-user"  style={{
+        backgroundColor: mode === 'dark' ? 'black' : 'white',
+        color: mode === 'dark' ? 'white' : 'black',
+      }}></i>
         </div>
         <div className="inp">
           <input

--- a/client/src/component/Signup.jsx
+++ b/client/src/component/Signup.jsx
@@ -2,6 +2,7 @@ import { Eye, EyeOff, Lock, Mail, User } from "lucide-react";
 import PropTypes from "prop-types";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import {  Input  } from "antd";
 import "./css/Login.css";
 import { registerValidation } from "../validations/validation";
 
@@ -263,7 +264,7 @@ const Signup = (props) => {
         <h1 className="title">Sign Up</h1>
         <span className="title-line"></span>
         <div className="inp">
-          <input
+          <Input
             type="text"
             className="input"
             placeholder="Name"

--- a/client/src/component/css/Login.css
+++ b/client/src/component/css/Login.css
@@ -58,6 +58,7 @@ body{
     padding-right: 10px;
     font-size: 17px;
 }
+
 .submit{
     border: none;
     outline: none;


### PR DESCRIPTION
Css input error in dark mode on login/signup page #98 

#98 Problem solved
The empty input field in dark mode error is solved by changing some of the css properties

**Title:**

**Issue No.:**

Close #98

![Screenshot 2024-10-15 204220](https://github.com/user-attachments/assets/aef15e22-ff78-4705-8541-f2fe3b86e246)

---

# Checklist:

<!-- [X] - put a cross/X inside [] to check the box -->

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have created a helpful and easy-to-understand `README.md` if it's a new page/tech stack.
- [x] I have gone through the `contributing.md` file before contributing.

**Additional context (Mandatory):**

**_Are you contributing under any Open-source programme?_**

<!-- Mention it here -->
<!-- [X] - put a cross/X inside [] to check the box -->

- [x] I'm a GSSOC-EXT contributor
- [x] I'm a HACKTOBERFEST contributor
