### PR TITLE
Improve the styling of FAQ section

### DIFF
--- a/client/src/component/css/About.css
+++ b/client/src/component/css/About.css
@@ -640,6 +640,15 @@ h2 {
 .faq-section .container {
   max-width:70vw ;
   padding: 2rem;
+
+    bottom: 3rem;
+    background-color: #c6fdff;
+    border-radius: 2rem;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.3);
+}
+
+.Heading-Page {
+  color: #16538f;
 }
 
 .faq-section {
@@ -653,6 +662,8 @@ h2 {
 /* Style for the accordion body */
 .accordion-body {
   background-color: #fff;
+  background: #bef5ff;
+ 
   border-radius: 5px;
   outline: 1px solid #ced4da;
   color: #1000ff;
@@ -669,6 +680,8 @@ h2 {
 /* Style for the accordion buttons */
 .accordion-button {
   background-color: rgb(238, 241, 248);
+
+  background: #8fe1f1;
   border-bottom: 4px solid rgb(255, 255, 255);
   border-radius: 5px;
   padding: 10px;


### PR DESCRIPTION
fixes issue no - #155

<!-- Please make sure issue number is mentioned in Pull Request else PR will not be merged. -->

**Title:**
Improve the styling of FAQ section


---

# Screenshots/Video (mandatory)
before:
![faq 180ct](https://github.com/user-attachments/assets/0c3e96e1-37c6-493c-8a25-342771a54955)


after:
![faq 190ct](https://github.com/user-attachments/assets/5345ab01-28b8-4ee5-a059-472b516fb5cf)



---

# Checklist:

<!-- [X] - put a cross/X inside [] to check the box -->

- [x ] I have mentioned the issue number in my Pull Request.



**Additional context (Mandatory):**

**_Are you contributing under any Open-source programme?_**
GSSOC'24 and Hacktofest'24

<!-- Mention it here -->
<!-- [X] - put a cross/X inside [] to check the box -->

- [ x] I'm a GSSOC-EXT contributor
- [ x] I'm a HACKTOBERFEST contributor
